### PR TITLE
interpark openAPI cors error ...

### DIFF
--- a/client/src/components/BookCard.jsx
+++ b/client/src/components/BookCard.jsx
@@ -36,7 +36,7 @@ export default function BookCard() {
 		<div className="container">
 			<div className="row">
 				<div className="col-md-3">
-					<img alt='' src='https://bimage.interpark.com/partner/goods_image/2/5/3/1/356522531h.jpg' />
+					<img alt='' src='https://bimage.interpark.com/partner/goods_image/2/5/3/1/356522531h.jpg' /> 
 					<h6>제목 :</h6>
 					<p>dd</p>
 				</div>


### PR DESCRIPTION
인터파크 도서 open API 사용해보려 했지만
CORS에러 해결하기가 쉽지않다...

1. axios보낼때 headers에 Access-Control-Allow-Origin: * 을 추가 하는 방법( 안됨 )
`axios.get(apiurl, { 
			headers: { 'Access-Control-Allow-Origin' : '*',
			'Access-Control-Allow-Methods' : 'POST, PUT, PATCH, GET, DELETE, OPTIONS',
			'Access-Control-Allow-Headers' : 'Origin, X-Api-Key, X-Requested-With, Content-Type, Accept, Authorization',
			'Access-Control-Allow-Credentials' : 'true'
		}})`
2. setupProxy.jsx 파일에 createProxyMiddleware설정 ( 안됨 )
`app.use(
    "/interpark",
    createProxyMiddleware({
      target: "http://book.interpark.com",
      changeOrigin: true,
      pathRewrite: {
        '^/interpark':''
      },
    })
  );`
axios에서 요청apiURL의 http://book.interpark.com ~부분을 interpark로 놓고 보내기도 안됨

구글검색 더 고고


